### PR TITLE
Fixed logging to RabbitMQ

### DIFF
--- a/projects/b2stage/backend/apis/commons/queue.py
+++ b/projects/b2stage/backend/apis/commons/queue.py
@@ -99,11 +99,8 @@ def log_into_queue(instance, dictionary_message):
     """ RabbitMQ in the EUDAT infrastructure """
 
     current_exchange = QUEUE_VARS.get('exchange')
-    current_queue = QUEUE_VARS.get('queue')
-    # FIXME: as variables
-    # app_name = 'requestlogs'
-    # app_name = 'maris_elk_test'
-    app_name = current_queue
+    routing_key = QUEUE_VARS.get('queue')
+    app_name = routing_key
 
     try:
 
@@ -113,14 +110,14 @@ def log_into_queue(instance, dictionary_message):
 
         msg_queue = instance.get_service_instance(QUEUE_SERVICE)
         log.verbose('Retrieved instance of log-queue service "%s"', QUEUE_SERVICE)
-        msg_queue.log_json_to_queue(dictionary_message, app_name, current_exchange, current_queue)
+        msg_queue.log_json_to_queue(dictionary_message, app_name, current_exchange, routing_key)
 
 
     except BaseException as e:
         log.error("Failed to log:\n%s(%s)", e.__class__.__name__, e)
     else:
         log.verbose('Log message passed to log-queue service.')
-        # log.verbose("%s: sent msg '%s'", current_queue, dictionary_message)
+        # log.verbose("%s: sent msg '%s'", routing_key, dictionary_message)
 
         # NOTE: bad! all connections would result in closed
         # # close resource

--- a/projects/b2stage/backend/apis/commons/queue.py
+++ b/projects/b2stage/backend/apis/commons/queue.py
@@ -78,7 +78,23 @@ def prepare_message(instance, user=None, isjson=False, **params):
     # log.pp(logmsg)
     return logmsg
 
+'''
+Send a log message into the logging queue, so that it
+ends up in ElasticSearch.
 
+It needs the following info from config:
+
+* RABBIT_EXCHANGE (where the message is sent to to be
+    distributed to a queue).
+* RABBIT_QUEUE (will be used as routing key to route the
+    message to the correct queue).
+* RABBIT_APP_NAME (will determine the name of the
+    ElasticSearch index where the message will be stored.
+    If not provided, the value of RABBIT_QUEUE will be used).
+
+:param instance: Instance of the Logging service from rapydo.
+:param dictionary_message: The message to be logged (as JSON).
+'''
 def log_into_queue(instance, dictionary_message):
     """ RabbitMQ in the EUDAT infrastructure """
 
@@ -104,10 +120,11 @@ def log_into_queue(instance, dictionary_message):
     app_name = current_queue
 
     try:
-        ###########
-        # connect
-        # FIXME: error seem to be raised if we don't refresh connection?
+
+        # Error seem to be raised if we don't refresh connection?
         # https://github.com/pika/pika/issues/397#issuecomment-35322410
+        # --> Has to be handled in rapydo/http-api, where connection is defined!
+
         msg_queue = instance.get_service_instance(QUEUE_SERVICE)
         log.verbose('Retrieved instance of log-queue service "%s"', QUEUE_SERVICE)
         msg_queue.log_json_to_queue(dictionary_message, app_name, current_exchange, current_queue)

--- a/projects/b2stage/backend/apis/commons/queue.py
+++ b/projects/b2stage/backend/apis/commons/queue.py
@@ -17,7 +17,11 @@ log = get_logger(__name__)
 QUEUE_SERVICE = 'rabbit'
 QUEUE_VARS = detector.load_group(label=QUEUE_SERVICE)
 
+'''
+:param instance: The Endpoint.
+:param params: The kv pairs to be in the log message.
 
+'''
 def prepare_message(instance, user=None, isjson=False, **params):
     """
 { # start
@@ -42,37 +46,37 @@ def prepare_message(instance, user=None, isjson=False, **params):
     "log_string":"end"
 }
     """
-    obj = dict(params)
+    logmsg = dict(params)
 
     instance_id = str(id(instance))
-    obj['request_id'] = instance_id
-    # obj['request_id'] = instance_id[len(instance_id) - 6:]
+    logmsg['request_id'] = instance_id
+    # logmsg['request_id'] = instance_id[len(instance_id) - 6:]
 
     from b2stage.apis.commons.seadatacloud import seadata_vars
-    obj['edmo_code'] = seadata_vars.get('edmo_code')
+    logmsg['edmo_code'] = seadata_vars.get('edmo_code')
 
     from datetime import datetime
-    obj['datetime'] = datetime.now().strftime("%Y%m%dT%H:%M:%S")
+    logmsg['datetime'] = datetime.now().strftime("%Y%m%dT%H:%M:%S")
 
     if isjson:
-        return obj
+        return logmsg
 
     from restapi.services.authentication import BaseAuthentication as Service
     ip, _ = Service.get_host_info()
-    obj['ip_number'] = ip
-    # obj['hostname'] = hostname
+    logmsg['ip_number'] = ip
+    # logmsg['hostname'] = hostname
 
     from flask import request
     # http://localhost:8080/api/pids/<PID>
     import re
     endpoint = re.sub(r"https?://[^\/]+", '', request.url)
-    obj['program'] = request.method + ':' + endpoint
+    logmsg['program'] = request.method + ':' + endpoint
     if user is None:
         user = 'import_manager'
-    obj['user'] = user
+    logmsg['user'] = user
 
-    # log.pp(obj)
-    return obj
+    # log.pp(logmsg)
+    return logmsg
 
 
 def log_into_queue(instance, dictionary_message):

--- a/projects/b2stage/backend/apis/commons/queue.py
+++ b/projects/b2stage/backend/apis/commons/queue.py
@@ -99,7 +99,6 @@ def log_into_queue(instance, dictionary_message):
     current_exchange = QUEUE_VARS.get('exchange')
     current_queue = QUEUE_VARS.get('queue')
     # FIXME: as variables
-    filter_code = 'de.dkrz.seadata.filter_code.foo.json'
     # app_name = 'requestlogs'
     # app_name = 'maris_elk_test'
     app_name = current_queue
@@ -110,25 +109,14 @@ def log_into_queue(instance, dictionary_message):
         # FIXME: error seem to be raised if we don't refresh connection?
         # https://github.com/pika/pika/issues/397#issuecomment-35322410
         msg_queue = instance.get_service_instance(QUEUE_SERVICE)
-        log.verbose("Connected to %s", QUEUE_SERVICE)
+        log.verbose('Retrieved instance of log-queue service "%s"', QUEUE_SERVICE)
+        msg_queue.log_json_to_queue(dictionary_message, app_name, current_exchange, current_queue)
 
-        ###########
-        # channel.queue_declare(queue=current_queue)  # not necessary if exists
-        channel = msg_queue.channel()  # send a message
-        channel.basic_publish(
-            exchange=current_exchange, routing_key=current_queue,
-            properties=pika.BasicProperties(
-                delivery_mode=2,
-                headers={'app_name': app_name, 'filter_code': filter_code},
-            ),
-            body=json.dumps(dictionary_message),
-        )
-    # except (ChannelClosed, ConnectionClosed):
-    #     pass
+
     except BaseException as e:
         log.error("Failed to log:\n%s(%s)", e.__class__.__name__, e)
     else:
-        log.verbose('Queue msg sent')
+        log.verbose('Log message passed to log-queue service.')
         # log.verbose("%s: sent msg '%s'", current_queue, dictionary_message)
 
         # NOTE: bad! all connections would result in closed

--- a/projects/b2stage/backend/apis/commons/queue.py
+++ b/projects/b2stage/backend/apis/commons/queue.py
@@ -59,7 +59,7 @@ def prepare_message(instance, user=None, isjson=False, **params):
     logmsg['datetime'] = datetime.now().strftime("%Y%m%dT%H:%M:%S")
 
     if isjson:
-        return logmsg
+        return logmsg # TODO Why this? Why does isjson exist at all?
 
     from restapi.services.authentication import BaseAuthentication as Service
     ip, _ = Service.get_host_info()
@@ -72,7 +72,7 @@ def prepare_message(instance, user=None, isjson=False, **params):
     endpoint = re.sub(r"https?://[^\/]+", '', request.url)
     logmsg['program'] = request.method + ':' + endpoint
     if user is None:
-        user = 'import_manager'
+        user = 'import_manager' # TODO: True? Not sure!
     logmsg['user'] = user
 
     # log.pp(logmsg)

--- a/projects/b2stage/backend/apis/commons/queue.py
+++ b/projects/b2stage/backend/apis/commons/queue.py
@@ -98,12 +98,16 @@ It needs the following info from config:
 def log_into_queue(instance, dictionary_message):
     """ RabbitMQ in the EUDAT infrastructure """
 
+    log.verbose('LOG MESSAGE to be passed to log-queue: %s ' % dictionary_message)
+
     current_exchange = QUEUE_VARS.get('exchange')
     routing_key = QUEUE_VARS.get('queue')
     app_name = QUEUE_VARS.get('app_name')
 
     if app_name is None:
         app_name = routing_key
+
+    log.debug('Log-queue service: exchange "%s", routing key "%s", app name "%s"' % (current_exchange, routing_key, app_name))
 
     try:
 
@@ -125,6 +129,7 @@ def log_into_queue(instance, dictionary_message):
         # NOTE: bad! all connections would result in closed
         # # close resource
         # msg_queue.close()
+        # FIXME: Close it elsewhere! Catching sigkill for example.
 
     return True
 

--- a/projects/b2stage/backend/apis/commons/queue.py
+++ b/projects/b2stage/backend/apis/commons/queue.py
@@ -98,10 +98,6 @@ It needs the following info from config:
 def log_into_queue(instance, dictionary_message):
     """ RabbitMQ in the EUDAT infrastructure """
 
-    from restapi.confs import PRODUCTION
-    if not PRODUCTION:
-        return False
-
     current_exchange = QUEUE_VARS.get('exchange')
     current_queue = QUEUE_VARS.get('queue')
     # FIXME: as variables

--- a/projects/b2stage/backend/apis/commons/queue.py
+++ b/projects/b2stage/backend/apis/commons/queue.py
@@ -98,19 +98,9 @@ It needs the following info from config:
 def log_into_queue(instance, dictionary_message):
     """ RabbitMQ in the EUDAT infrastructure """
 
-    ############
-    ############
-    # FIXME: not working at the moment
-    return True
-    ############
-    ############
-
     from restapi.confs import PRODUCTION
     if not PRODUCTION:
         return False
-
-    ############
-    # LOGGING
 
     current_exchange = QUEUE_VARS.get('exchange')
     current_queue = QUEUE_VARS.get('queue')

--- a/projects/b2stage/backend/apis/commons/queue.py
+++ b/projects/b2stage/backend/apis/commons/queue.py
@@ -100,7 +100,10 @@ def log_into_queue(instance, dictionary_message):
 
     current_exchange = QUEUE_VARS.get('exchange')
     routing_key = QUEUE_VARS.get('queue')
-    app_name = routing_key
+    app_name = QUEUE_VARS.get('app_name')
+
+    if app_name is None:
+        app_name = routing_key
 
     try:
 

--- a/projects/b2stage/backend/apis/ingestion.py
+++ b/projects/b2stage/backend/apis/ingestion.py
@@ -107,6 +107,15 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
 
         if backdoor and icom.is_dataobject(ipath):
             response['status'] = 'exists'
+
+            # Log end (of upload) into RabbitMQ
+            # In case it already existed!
+            log_msg = prepare_message(self,
+                user = ingestion_user,
+                log_string = 'end', # TODO True?
+                status = response['status']
+            )
+            log_into_queue(self, log_msg)
             return response
 
         ########################

--- a/projects/b2stage/backend/apis/ingestion.py
+++ b/projects/b2stage/backend/apis/ingestion.py
@@ -61,6 +61,8 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
         Let the Replication Manager upload a zip file into a batch folder
         """
 
+        log.info('Received request to upload batch "%s"' % batch_id)
+
         # Log start (of upload) into RabbitMQ
         log_msg = prepare_message(
             self, json={'batch_id': batch_id, 'file_id': file_id},
@@ -221,10 +223,13 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
         param_name = 'batch_id'
         self.get_input()
         batch_id = self._args.get(param_name, None)
+
         if batch_id is None:
             return self.send_errors(
                 "Mandatory parameter '%s' missing" % param_name,
                 code=hcodes.HTTP_BAD_REQUEST)
+
+        log.info('Received request to enable batch "%s"' % batch_id)
 
         # Log start (of enable) into RabbitMQ
         log_msg = prepare_message(

--- a/projects/b2stage/backend/apis/ingestion.py
+++ b/projects/b2stage/backend/apis/ingestion.py
@@ -61,11 +61,11 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
         Let the Replication Manager upload a zip file into a batch folder
         """
 
-        ##################
-        msg = prepare_message(
+        # Log start (of upload) into RabbitMQ
+        log_msg = prepare_message(
             self, json={'batch_id': batch_id, 'file_id': file_id},
             user=ingestion_user, log_string='start')
-        log_into_queue(self, msg)
+        log_into_queue(self, log_msg)
 
         ########################
         # get irods session
@@ -181,11 +181,12 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
         response['errors'] = errors
         # response = "Batch '%s' filled" % batch_id
 
-        #############################
-        msg = prepare_message(
+        # Log end (of upload) into RabbitMQ
+        log_msg = prepare_message(
             self, status=response['status'],
             user=ingestion_user, log_string='end')
-        log_into_queue(self, msg)
+        log_into_queue(self, log_msg)
+
 
         return self.force_response(response)
 
@@ -202,11 +203,11 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
                 "Mandatory parameter '%s' missing" % param_name,
                 code=hcodes.HTTP_BAD_REQUEST)
 
-        ##################
-        msg = prepare_message(
+        # Log start (of enable) into RabbitMQ
+        log_msg = prepare_message(
             self, json={'batch_id': batch_id},
             user=ingestion_user, log_string='start')
-        log_into_queue(self, msg)
+        log_into_queue(self, log_msg)
 
         ##################
         # Get irods session
@@ -240,8 +241,9 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
             response = "Batch '%s' already exists" % batch_id
             status = 'exists'
 
-        ##################
-        msg = prepare_message(
+        # Log end (of enable) into RabbitMQ
+        log_msg = prepare_message(
             self, status=status, user=ingestion_user, log_string='end')
-        log_into_queue(self, msg)
+        log_into_queue(self, log_msg)
+
         return self.force_response(response)


### PR DESCRIPTION
This code fixes the logging of messages to a RabbitMQ instance.

(TCP connections to the RabbitMQ instance are not handled by this repo anymore, but in rapydo/http-api. Also, logging into file instead of into a RabbitMQ instance in non-production mode is now handled by rapydo. See PR #18 https://github.com/rapydo/http-api/pull/18 ).

This was tested with rapydo 0.6.3 (plus applied updates, see PR #18 which I have opened some minutes ago).

Tested:
- Log the start of enabling a batch
- Log the successful end of enabling a batch
- Log the end of enabling a batch, if the batch was already enabled
- Log the start of uploading a file
- Log the successful end of uploading a file
- Log the end of uploading a file, if the file had already existed

