### PR TITLE
Bug fix in rancher (missing variable).

### DIFF
--- a/projects/b2stage/backend/apis/services/rancher.py
+++ b/projects/b2stage/backend/apis/services/rancher.py
@@ -233,8 +233,8 @@ class Rancher(object):
         return obj
 
     def run(self,
-            container_name, image_name,
-            private=False, extras=None, wait_stopped=False, pull=True,
+            container_name, image_name, wait_running=None,
+            private=False, extras=None, wait_stopped=None, pull=True,
             ):
 
         ############


### PR DESCRIPTION
Missing variable will make rancher.run() fail in every case!
Analog to PR #124 