### PR TITLE
Catch rare exception during enable and return error to client.

### DIFF
--- a/projects/b2stage/backend/apis/ingestion.py
+++ b/projects/b2stage/backend/apis/ingestion.py
@@ -253,6 +253,14 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
         # Does it already exist? Is it a collection?
         if not imain.is_collection(batch_path):
 
+            # Create the path and set permissions in irods
+            batch_path = self.get_irods_batch_path(imain, batch_id)
+            imain.create_collection_inheritable(batch_path, obj.username)
+            # # Remove anonymous access to this batch
+            # ianonymous.set_permissions(
+            #     batch_path,
+            #     permission='null', userOrGroup=icom.anonymous_user)
+
             # Create directory on file system:
             try:
                 local_path = path.join(MOUNTPOINT, INGESTION_DIR, batch_id)
@@ -261,16 +269,12 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
             except FileNotFoundError as e:
                 err_msg = ('Could not create directory "%s" (%s)' % (local_path, e))
                 log.critical(err_msg)
+                log.info('Removing collection from irods (%s)' % batch_path)
+                imain.remove(batch_path, recursive=True, force=True)
                 return self.send_errors(err_msg,
                     code=hcodes.HTTP_SERVER_ERROR)
 
-            # Create the path and set permissions in irods
-            batch_path = self.get_irods_batch_path(imain, batch_id)
-            imain.create_collection_inheritable(batch_path, obj.username)
-            # # Remove anonymous access to this batch
-            # ianonymous.set_permissions(
-            #     batch_path,
-            #     permission='null', userOrGroup=icom.anonymous_user)
+
 
             ##################
             response = "Batch '%s' enabled" % batch_id

--- a/projects/b2stage/backend/apis/ingestion.py
+++ b/projects/b2stage/backend/apis/ingestion.py
@@ -247,7 +247,7 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
         imain = self.get_service_instance(service_name='irods')
 
         batch_path = self.get_irods_batch_path(imain, batch_id)
-        log.info("Batch path: %s", batch_path)
+        log.info("Batch irods path: %s", batch_path)
 
         ##################
         # Does it already exist? Is it a collection?

--- a/projects/b2stage/backend/apis/ingestion.py
+++ b/projects/b2stage/backend/apis/ingestion.py
@@ -260,8 +260,18 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
             # ianonymous.set_permissions(
             #     batch_path,
             #     permission='null', userOrGroup=icom.anonymous_user)
-            local_path = path.join(MOUNTPOINT, INGESTION_DIR, batch_id)
-            path.create(local_path, directory=True, force=True)
+
+            # Create directory on file system:
+            try:
+                local_path = path.join(MOUNTPOINT, INGESTION_DIR, batch_id)
+                log.info("Batch local path: %s", local_path)
+                path.create(local_path, directory=True, force=True)
+            except FileNotFoundError as e:
+                err_msg = ('Could not create directory "%s" (%s)' % (local_path, e))
+                log.critical(err_msg)
+                log.info('Please delete collection here!!') # TODO!
+                return self.send_errors(err_msg,
+                    code=hcodes.HTTP_SERVER_ERROR)
 
             ##################
             response = "Batch '%s' enabled" % batch_id

--- a/projects/b2stage/backend/apis/ingestion.py
+++ b/projects/b2stage/backend/apis/ingestion.py
@@ -267,7 +267,7 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
             try:
                 # TODO: REMOVE THIS WHEN path.create() has parents=True!
                 import os
-                superdir = os.path.join(LOCALPATH, INGESTION_DIR)
+                superdir = os.path.join(MOUNTPOINT, INGESTION_DIR)
                 if not os.path.exists(superdir):
                     log.debug('Creating %s...', superdir)
                     os.mkdir(superdir)

--- a/projects/b2stage/backend/apis/ingestion.py
+++ b/projects/b2stage/backend/apis/ingestion.py
@@ -252,14 +252,6 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
         ##################
         # Does it already exist? Is it a collection?
         if not imain.is_collection(batch_path):
-            # Enable the batch
-            batch_path = self.get_irods_batch_path(imain, batch_id)
-            # Create the path and set permissions
-            imain.create_collection_inheritable(batch_path, obj.username)
-            # # Remove anonymous access to this batch
-            # ianonymous.set_permissions(
-            #     batch_path,
-            #     permission='null', userOrGroup=icom.anonymous_user)
 
             # Create directory on file system:
             try:
@@ -269,9 +261,16 @@ class IngestionEndpoint(Uploader, EudatEndpoint, ClusterContainerEndpoint):
             except FileNotFoundError as e:
                 err_msg = ('Could not create directory "%s" (%s)' % (local_path, e))
                 log.critical(err_msg)
-                log.info('Please delete collection here!!') # TODO!
                 return self.send_errors(err_msg,
                     code=hcodes.HTTP_SERVER_ERROR)
+
+            # Create the path and set permissions in irods
+            batch_path = self.get_irods_batch_path(imain, batch_id)
+            imain.create_collection_inheritable(batch_path, obj.username)
+            # # Remove anonymous access to this batch
+            # ianonymous.set_permissions(
+            #     batch_path,
+            #     permission='null', userOrGroup=icom.anonymous_user)
 
             ##################
             response = "Batch '%s' enabled" % batch_id


### PR DESCRIPTION
This PR addresses issue https://github.com/EUDAT-B2STAGE/http-api/issues/138

If the directory cannot be created, this is critical - the whole batch cannot be processed if this fails. So I return an error, but the problem definitely has to be solved on the server, not by the client.

TODO: The collection should definitely be deleted from irods, so that no success is returned when the client tries the same request a second time! I did not find a delete function in the rapydo irods client, that's why I did not do this yet.